### PR TITLE
fix: correct SonarCloud opencover glob pattern for coverlet.MTP output

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -172,7 +172,7 @@ jobs:
           /o:"demaconsulting"
           /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
           /d:sonar.host.url="https://sonarcloud.io"
-          /d:sonar.cs.opencover.reportsPaths=**/*.opencover.xml
+          /d:sonar.cs.opencover.reportsPaths=**/coverage.opencover.*.xml
           /d:sonar.scanner.scanAll=false
 
       - name: Build


### PR DESCRIPTION
SonarCloud reports zero code coverage for this repo. This project uses xunit.v3 4.0.0, which only runs under the Microsoft.Testing.Platform (MTP) 'dotnet test' mode, so the test project correctly uses coverlet.MTP (the VSTest-only coverlet.collector doesn't work under MTP). However, coverlet.MTP names its output file
coverage.opencover.<numeric-session-id>.xml, whereas the workflow's Sonar scanner argument used the glob **/*.opencover.xml, which only matches filenames literally ending in "opencover.xml" - the session-ID segment breaks that match, so the scanner silently found no coverage report to ingest.

Verified locally: `dotnet test --coverlet --coverlet-output-format opencover` (matching CI) produces files such as
coverage.opencover.280826142250915.xml, which the corrected glob **/coverage.opencover.*.xml matches but the old glob did not. All 1701 tests still pass.